### PR TITLE
ci: add Dockerfile and goreleaser docker image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,17 @@ builds:
       - windows
       - darwin
     binary: tagger
+dockers:
+  # build latest and specific tag version images
+  - image_templates:
+      - "tjhop/{{.ProjectName}}:{{ .Tag }}"
+      - "tjhop/{{.ProjectName}}:latest"
+      # push to github container registry too
+      - "ghcr.io/tjhop/{{.ProjectName}}:{{ .Tag }}"
+      - "ghcr.io/tjhop/{{.ProjectName}}:latest"
+    goos: linux
+    goarch: amd64
+    use: docker
 archives:
   - replacements:
       darwin: Darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.18-alpine
+COPY tagger /usr/bin/tagger
+ENTRYPOINT ["/usr/bin/tagger"]
+CMD ["--config", "/etc/tagger/tagger.yml"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This application may be updated in the future to support enforcing tag sets on o
 LINODE_TOKEN="${your_api_token}" tagger --config /etc/tagger/tagger.yml
 ```
 
+### Docker Usage
+
+Provide a Linode APIv4 token with appropriate scope to tag your desired objects as an environment variable, along with a bind mount volume for the linode-tagger configuration.
+
+```
+docker run \
+-e LINODE_TOKEN="<linode-api-v4-token>" \
+-v /path/to/tagger.yml:/etc/tagger/tagger.yml \
+ghcr.io/tjhop/linode-tagger
+```
+
 ## Building
 
 This project uses [goreleaser](https://goreleaser.com/) to manage builds.


### PR DESCRIPTION
This sets up GoReleaser to build Docker images; `latest` and specific
version tags that will push to the GitHub container registry and also
provide local images.

A configuration file is also copied into the Dockerfile. A LINODE_TOKEN
environment variable must be passed to the docker image with the `-e`
docker run option or similar.

@tjhop off the bat, I wasn't sure how to handle adding `./packaging/etc/tagger.yml` to the build properly, what I have now feels sub optimal