### PR TITLE
feat: add support for all taggable Linode objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Linode Tagger
 
-Tagger is an application that can enforce the presence/absence of API tags in bulk across all of your Linode instances.
-_Note_: currently, `tagger` only supports Linode instances.
-This application may be updated in the future to support enforcing tag sets on other Linode APIv4 resource objects.
+Tagger is an application that can enforce the presence/absence of API tags in bulk across all taggable Linode APIv4 resource objects:
+
+* Instances
+* Volumes
+* NodeBalancers
+* Domains
+* LKEClusters
 
 ## Usage
 

--- a/packaging/etc/tagger.yml
+++ b/packaging/etc/tagger.yml
@@ -27,7 +27,7 @@ tagger:
       present:
         - tagger_managed_1
       absent: []
-  lkeclusters:
+  lke_clusters:
   - regex: '.+'
     tags:
       present:

--- a/packaging/etc/tagger.yml
+++ b/packaging/etc/tagger.yml
@@ -6,3 +6,10 @@ tagger:
         - tagger_managed_1
       absent:
         - tagger_absent_1
+  volumes:
+  - regex: '.+'
+    tags:
+      present:
+        - tagger_absent_1
+      absent:
+        - tagger_managed_1

--- a/packaging/etc/tagger.yml
+++ b/packaging/etc/tagger.yml
@@ -10,6 +10,29 @@ tagger:
   - regex: '.+'
     tags:
       present:
-        - tagger_absent_1
-      absent:
         - tagger_managed_1
+      absent:
+        - tagger_absent_1
+  nodebalancers:
+  - regex: 'ccm.+'
+    tags:
+      present:
+        - tagger_managed_1
+        - lke
+      absent:
+        - tagger_absent_1
+  domains:
+  - regex: '.+'
+    tags:
+      present:
+        - tagger_managed_1
+      absent: []
+  lkeclusters:
+  - regex: '.+'
+    tags:
+      present:
+        - tagger_managed_1
+        - lke
+      absent:
+        - tagger_absent_1
+        - tagger_absent_2

--- a/tagger.go
+++ b/tagger.go
@@ -24,8 +24,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type instanceTagMap map[int][]string
-type ReportMap map[string]ReportData
+type instanceTagMap map[string]map[int][]string
+type ReportMap map[string]map[string]ReportData
 
 type ReportData struct {
 	InstancesAdded   []string
@@ -41,7 +41,11 @@ type TagRule struct {
 	Tags  TagSet `yaml:"tags,omitempty" mapstructure:"tags"`
 }
 type TaggerConfig struct {
-	Instances []TagRule `yaml:"instances"`
+	Instances     []TagRule `yaml:"instances"`
+	Volumes       []TagRule `yaml:"volumes"`
+	NodeBalancers []TagRule `yaml:"nodebalancers"`
+	Domains       []TagRule `yaml:"domains"`
+	LKEClusters   []TagRule `yaml:"lkeclusters"`
 }
 
 func newLinodeClient() linodego.Client {
@@ -65,85 +69,240 @@ func newLinodeClient() linodego.Client {
 	return client
 }
 
-func checkLinodeTagsAgainstConfig(linodes []linodego.Instance, rules []TagRule) (instanceTagMap, error) {
-	linodeIDTagMap := make(instanceTagMap)
+func compareTags(linodeObject interface{}, linodeTags []TagRule) (combinedNewTags []string, tags []string, linodeID int) {
 
-	for _, linode := range linodes {
-		tags := linode.Tags
-		sort.Strings(tags)
-		var combinedNewTags []string
-		for _, rule := range rules {
-			validInstance := regexp.MustCompile(rule.Regex)
+	var label string
+	switch linode := linodeObject.(type) {
+	case linodego.Instance:
+		tags = linode.Tags
+		label = linode.Label
+		linodeID = linode.ID
+	case linodego.Volume:
+		tags = linode.Tags
+		label = linode.Label
+		linodeID = linode.ID
+	case linodego.NodeBalancer:
+		tags = linode.Tags
+		label = *linode.Label
+		linodeID = linode.ID
+	case linodego.Domain:
+		tags = linode.Tags
+		label = linode.Domain
+		linodeID = linode.ID
+	case linodego.LKECluster:
+		tags = linode.Tags
+		label = linode.Label
+		linodeID = linode.ID
+	}
 
-			if validInstance.MatchString(linode.Label) {
-				var newTags []string
+	sort.Strings(tags)
 
-				// check `absent` tags to remove unwanted tags
-				for _, tag := range tags {
-					if !slices.Contains(rule.Tags.Absent, tag) {
-						// if this tag is not on the `absent` list,
-						// we can persist it through to the new tag set
-						newTags = append(newTags, tag)
-					}
-				}
+	for _, rule := range linodeTags {
+		validInstance := regexp.MustCompile(rule.Regex)
 
-				// check `present` tags to ensure specific tags exist
-				for _, tag := range rule.Tags.Present {
-					// compare filter against `newTags`, as
-					// newTags == (the linode's tags - absent tags)
-					if !slices.Contains(newTags, tag) {
-						// if the specified tag does not exist,
-						// add it into the new tag set
-						newTags = append(newTags, tag)
-					}
-				}
+		if validInstance.MatchString(label) {
+			var newTags []string
 
-				// add newTags to combined list of new tags for this instance,
-				// excluding duplicates
-				for _, tag := range newTags {
-					if !slices.Contains(combinedNewTags, tag) {
-						combinedNewTags = append(combinedNewTags, tag)
-					}
+			// check `absent` tags to remove unwanted tags
+			for _, tag := range tags {
+				if !slices.Contains(rule.Tags.Absent, tag) {
+					// if this tag is not on the `absent` list,
+					// we can persist it through to the new tag set
+					newTags = append(newTags, tag)
 				}
 			}
-		}
 
-		if len(combinedNewTags) > 0 {
-			linodeIDTagMap[linode.ID] = combinedNewTags
-			sort.Strings(combinedNewTags)
-			if !slices.Equal(tags, combinedNewTags) {
-				log.WithFields(log.Fields{
-					"linode_id": linode.ID,
-					"old_tags":  tags,
-					"new_tags":  combinedNewTags,
-				}).Debug("Linode tag set updated")
+			// check `present` tags to ensure specific tags exist
+			for _, tag := range rule.Tags.Present {
+				// compare filter against `newTags`, as
+				// newTags == (the linode's tags - absent tags)
+				if !slices.Contains(newTags, tag) {
+					// if the specified tag does not exist,
+					// add it into the new tag set
+					newTags = append(newTags, tag)
+				}
+			}
+
+			// add newTags to combined list of new tags for this instance,
+			// excluding duplicates
+			for _, tag := range newTags {
+				if !slices.Contains(combinedNewTags, tag) {
+					combinedNewTags = append(combinedNewTags, tag)
+				}
 			}
 		}
 	}
 
-	return linodeIDTagMap, nil
+	return combinedNewTags, tags, linodeID
 }
 
-func updateLinodeInstanceTags(ctx context.Context, client linodego.Client, id int, tags *[]string) error {
-	updatedInstance, err := client.UpdateInstance(ctx, id, linodego.InstanceUpdateOptions{Tags: tags})
-	if err != nil {
-		return err
+func logTags(combinedNewTags []string, tags []string, linodeID int) {
+	if len(combinedNewTags) > 0 {
+		sort.Strings(combinedNewTags)
+		if !slices.Equal(tags, combinedNewTags) {
+			log.WithFields(log.Fields{
+				"linode_id": linodeID,
+				"old_tags":  tags,
+				"new_tags":  combinedNewTags,
+			}).Debug("Linode tag set updated")
+		}
+	}
+}
+
+func checkTagsAgainstConfig(
+	linodeObjects []interface{}, linodeTagSlice map[string][]TagRule) (instanceTagMap, error) {
+
+	instanceTagMap := make(instanceTagMap)
+
+	for _, objects := range linodeObjects {
+
+		var combinedNewTags, tags []string
+		var linodeID int
+
+		switch objects := objects.(type) {
+		case []linodego.Instance:
+
+			instanceType := "linodes"
+			instanceTagMap[instanceType] = make(map[int][]string)
+
+			if linodeTagSlice[instanceType] != nil {
+				for _, linode := range objects {
+
+					combinedNewTags, tags, linodeID = compareTags(linode, linodeTagSlice[instanceType])
+					instanceTagMap[instanceType][linodeID] = combinedNewTags
+					logTags(combinedNewTags, tags, linodeID)
+				}
+			}
+		case []linodego.Volume:
+
+			instanceType := "volumes"
+			instanceTagMap[instanceType] = make(map[int][]string)
+
+			if linodeTagSlice[instanceType] != nil {
+				for _, volume := range objects {
+					combinedNewTags, tags, linodeID = compareTags(volume, linodeTagSlice[instanceType])
+					instanceTagMap[instanceType][linodeID] = combinedNewTags
+					logTags(combinedNewTags, tags, linodeID)
+				}
+			}
+		case []linodego.NodeBalancer:
+
+			instanceType := "nodebalancers"
+			instanceTagMap[instanceType] = make(map[int][]string)
+
+			if linodeTagSlice[instanceType] != nil {
+				for _, nodebalancer := range objects {
+					combinedNewTags, tags, linodeID = compareTags(nodebalancer, linodeTagSlice[instanceType])
+					instanceTagMap[instanceType][linodeID] = combinedNewTags
+					logTags(combinedNewTags, tags, linodeID)
+				}
+			}
+		case []linodego.Domain:
+
+			instanceType := "domains"
+			instanceTagMap[instanceType] = make(map[int][]string)
+
+			if linodeTagSlice[instanceType] != nil {
+				for _, domain := range objects {
+					combinedNewTags, tags, linodeID = compareTags(domain, linodeTagSlice[instanceType])
+					instanceTagMap[instanceType][linodeID] = combinedNewTags
+					logTags(combinedNewTags, tags, linodeID)
+				}
+			}
+		case []linodego.LKECluster:
+
+			instanceType := "lkeclusters"
+			instanceTagMap[instanceType] = make(map[int][]string)
+
+			if linodeTagSlice[instanceType] != nil {
+				for _, lkecluster := range objects {
+					combinedNewTags, tags, linodeID = compareTags(lkecluster, linodeTagSlice[instanceType])
+					instanceTagMap[instanceType][linodeID] = combinedNewTags
+					logTags(combinedNewTags, tags, linodeID)
+				}
+			}
+		}
+
 	}
 
-	sort.Strings(*tags)
-	updatedTags := updatedInstance.Tags
-	sort.Strings(updatedTags)
-	if !slices.Equal(updatedTags, *tags) {
-		return errors.New("call to update instance did not result in the expected tag set")
+	return instanceTagMap, nil
+}
+
+func updateLinodeInstanceTags(ctx context.Context, client linodego.Client, id int, tags *[]string, data string) error {
+
+	if id != 0 {
+		switch data {
+		case "linodes":
+			updatedInstance, err := client.UpdateInstance(ctx, id, linodego.InstanceUpdateOptions{Tags: tags})
+			if err != nil {
+				return err
+			}
+			sort.Strings(*tags)
+			updatedTags := updatedInstance.Tags
+			sort.Strings(updatedTags)
+
+			if !slices.Equal(updatedTags, *tags) {
+				return errors.New("call to update instance did not result in the expected tag set")
+			}
+		case "volumes":
+			updatedInstance, err := client.UpdateVolume(ctx, id, linodego.VolumeUpdateOptions{Tags: tags})
+			if err != nil {
+				return err
+			}
+			sort.Strings(*tags)
+			updatedTags := updatedInstance.Tags
+			sort.Strings(updatedTags)
+
+			if !slices.Equal(updatedTags, *tags) {
+				return errors.New("call to update volume did not result in the expected tag set")
+			}
+		case "nodebalancers":
+			updatedInstance, err := client.UpdateNodeBalancer(ctx, id, linodego.NodeBalancerUpdateOptions{Tags: tags})
+			if err != nil {
+				return err
+			}
+			sort.Strings(*tags)
+			updatedTags := updatedInstance.Tags
+			sort.Strings(updatedTags)
+			if !slices.Equal(updatedTags, *tags) {
+				return errors.New("call to update nodebalancer did not result in the expected tag set")
+			}
+		case "domains":
+			updatedInstance, err := client.UpdateDomain(ctx, id, linodego.DomainUpdateOptions{Tags: *tags})
+			if err != nil {
+				return err
+			}
+			sort.Strings(*tags)
+			updatedTags := updatedInstance.Tags
+			sort.Strings(updatedTags)
+			if !slices.Equal(updatedTags, *tags) {
+				return errors.New("call to update domain did not result in the expected tag set")
+			}
+		case "lkeclusters":
+			updatedInstance, err := client.UpdateLKECluster(ctx, id, linodego.LKEClusterUpdateOptions{Tags: tags})
+			if err != nil {
+				return err
+			}
+			sort.Strings(*tags)
+			updatedTags := updatedInstance.Tags
+			sort.Strings(updatedTags)
+			if !slices.Equal(updatedTags, *tags) {
+				return errors.New("call to update lkecluster did not result in the expected tag set")
+			}
+
+		}
 	}
 
 	return nil
 }
 
 func updateAllInstanceTags(ctx context.Context, client linodego.Client, tagMap instanceTagMap) error {
-	for id, tags := range tagMap {
-		if err := updateLinodeInstanceTags(ctx, client, id, &tags); err != nil {
-			return err
+	for data := range tagMap {
+
+		for id, tags := range tagMap[data] {
+			if err := updateLinodeInstanceTags(ctx, client, id, &tags, data); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -166,42 +325,136 @@ func sliceDifference(a, b []string) []string {
 	return diff
 }
 
-func buildReport(desiredTagMap instanceTagMap, linodes []linodego.Instance) ReportMap {
+func compareTagData(tags []string, t []string, label string, originalRemoveData ReportData, originalAddData ReportData) (removeData ReportData, addData ReportData, addDiff []string, removeDiff []string) {
+	// our tags are different than we want - something will change. we need to populate the report
+	sort.Strings(tags)
+	sort.Strings(t)
+	if !slices.Equal(tags, t) {
+		// order of tags and linode.Tags differs based on whether we're subtracting or contributing more tags
+		addDiff = sliceDifference(tags, t)
+		removeDiff = sliceDifference(t, tags)
+		if len(removeDiff) > 0 {
+			removeData.InstancesRemoved = append(originalRemoveData.InstancesRemoved, label)
+		}
+		if len(addDiff) > 0 {
+			addData.InstancesAdded = append(originalAddData.InstancesAdded, label)
+		}
+	}
+	return removeData, addData, addDiff, removeDiff
+}
+
+func buildReport(desiredTagMap instanceTagMap, linodeObjects []interface{}) ReportMap {
 	// diff of returned instanceTagMap vs the instance tags
+
 	report := make(ReportMap)
+	var instanceType string
+	// iterate through every type of linode object and see what tags should change
+	for _, objects := range linodeObjects {
+		switch objects := objects.(type) {
+		case []linodego.Instance:
+			instanceType = "linodes"
+			report[instanceType] = make(map[string]ReportData)
 
-	for id, tags := range desiredTagMap {
-		// separate data stores based on whether we're adding or removing tags
-		var removeData, addData ReportData
-		var addDiff, removeDiff []string
-
-		for _, linode := range linodes {
-			if linode.ID == id {
-				// our tags are different than we want - something will change. we need to populate the report
-				sort.Strings(tags)
-				t := linode.Tags
-				sort.Strings(t)
-				if !slices.Equal(tags, t) {
-					// order of tags and linode.Tags differs based on whether we're subtracting or contributing more tags
-					addDiff = sliceDifference(tags, t)
-					removeDiff = sliceDifference(t, tags)
-					if len(removeDiff) > 0 {
-						removeData.InstancesRemoved = append(removeData.InstancesRemoved, linode.Label)
+			// separate data stores based on whether we're adding or removing tags
+			var addDiff, removeDiff []string
+			var removeData, addData ReportData
+			for id, tags := range desiredTagMap[instanceType] {
+				for _, linode := range objects {
+					if linode.ID == id {
+						removeData, addData, addDiff, removeDiff = compareTagData(tags, linode.Tags, linode.Label, removeData, addData)
 					}
-					if len(addDiff) > 0 {
-						addData.InstancesAdded = append(addData.InstancesAdded, linode.Label)
+					for _, tag := range addDiff {
+						report[instanceType][tag] = addData
+					}
+					for _, tag := range removeDiff {
+						report[instanceType][tag] = removeData
 					}
 				}
 			}
-		}
-		for _, tag := range addDiff {
-			report[tag] = addData
-		}
-		for _, tag := range removeDiff {
-			report[tag] = removeData
+
+		case []linodego.Volume:
+			instanceType = "volumes"
+			report[instanceType] = make(map[string]ReportData)
+
+			var addDiff, removeDiff []string
+			var removeData, addData ReportData
+			for id, tags := range desiredTagMap[instanceType] {
+				for _, volume := range objects {
+					if volume.ID == id {
+						removeData, addData, addDiff, removeDiff = compareTagData(tags, volume.Tags, volume.Label, removeData, addData)
+					}
+					for _, tag := range addDiff {
+						report[instanceType][tag] = addData
+					}
+					for _, tag := range removeDiff {
+						report[instanceType][tag] = removeData
+					}
+				}
+			}
+
+		case []linodego.NodeBalancer:
+			instanceType = "nodebalancers"
+			report[instanceType] = make(map[string]ReportData)
+
+			var addDiff, removeDiff []string
+			var removeData, addData ReportData
+			for id, tags := range desiredTagMap[instanceType] {
+				for _, nodebalancer := range objects {
+					if nodebalancer.ID == id {
+						removeData, addData, addDiff, removeDiff = compareTagData(tags, nodebalancer.Tags, *nodebalancer.Label, removeData, addData)
+					}
+					for _, tag := range addDiff {
+						report[instanceType][tag] = addData
+					}
+					for _, tag := range removeDiff {
+						report[instanceType][tag] = removeData
+					}
+				}
+			}
+
+		case []linodego.Domain:
+			instanceType = "domains"
+			report[instanceType] = make(map[string]ReportData)
+
+			var addDiff, removeDiff []string
+			var removeData, addData ReportData
+			for id, tags := range desiredTagMap[instanceType] {
+				for _, domain := range objects {
+					if domain.ID == id {
+						removeData, addData, addDiff, removeDiff = compareTagData(tags, domain.Tags, domain.Domain, removeData, addData)
+					}
+					for _, tag := range addDiff {
+						report[instanceType][tag] = addData
+					}
+					for _, tag := range removeDiff {
+						report[instanceType][tag] = removeData
+					}
+				}
+
+			}
+		case []linodego.LKECluster:
+			instanceType = "lkeclusters"
+			report[instanceType] = make(map[string]ReportData)
+
+			var addDiff, removeDiff []string
+			var removeData, addData ReportData
+			for id, tags := range desiredTagMap[instanceType] {
+				for _, lkecluster := range objects {
+					if lkecluster.ID == id {
+						removeData, addData, addDiff, removeDiff = compareTagData(tags, lkecluster.Tags, lkecluster.Label, removeData, addData)
+					}
+					for _, tag := range addDiff {
+						report[instanceType][tag] = addData
+					}
+					for _, tag := range removeDiff {
+						report[instanceType][tag] = removeData
+					}
+				}
+
+			}
+
 		}
 	}
-
 	return report
 }
 
@@ -209,28 +462,32 @@ func genReport(report ReportMap) error {
 	// create a pretty table
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(table.Row{"tag", "Linodes Changed", "Linodes", "Added/Removed"})
-	for tag, data := range report {
+	t.AppendHeader(table.Row{"tag", "Objects Changed", "Objects", "Object Type", "Added/Removed"})
+	for instanceType := range report {
+		for tag, data := range report[instanceType] {
 
-		addInstanceList := strings.Join(data.InstancesAdded, ", ")
-		removeInstanceList := strings.Join(data.InstancesRemoved, ", ")
+			addInstanceList := strings.Join(data.InstancesAdded, ", ")
+			removeInstanceList := strings.Join(data.InstancesRemoved, ", ")
 
-		removeCount := len(data.InstancesRemoved)
-		addCount := len(data.InstancesAdded)
-		if removeCount >= 1 {
-			t.AppendRow(table.Row{
-				tag,
-				removeCount,
-				removeInstanceList,
-				"Removed",
-			})
-		}
-		if addCount >= 1 {
-			t.AppendRow(table.Row{
-				tag,
-				addCount,
-				addInstanceList,
-				"Added"})
+			removeCount := len(data.InstancesRemoved)
+			addCount := len(data.InstancesAdded)
+			if removeCount >= 1 {
+				t.AppendRow(table.Row{
+					tag,
+					removeCount,
+					removeInstanceList,
+					instanceType,
+					"Removed",
+				})
+			}
+			if addCount >= 1 {
+				t.AppendRow(table.Row{
+					tag,
+					addCount,
+					addInstanceList,
+					instanceType,
+					"Added"})
+			}
 		}
 	}
 	t.SetAutoIndex(true)
@@ -246,17 +503,18 @@ func genReport(report ReportMap) error {
 
 func genJSON(report ReportMap) error {
 	// convert ReportMap to JSON and send to stdout
-	for tag, data := range report {
-		report[tag] = data
+	for instanceType := range report {
+		for tag, data := range report[instanceType] {
+			report[instanceType][tag] = data
+		}
 	}
 	stdout, err := json.Marshal(report)
 	fmt.Println(string(stdout))
 
-	if err == nil {
-		return nil
-	} else {
+	if err != nil {
 		return err
 	}
+	return nil
 }
 
 func init() {
@@ -340,13 +598,58 @@ func main() {
 	log.Info("Gathering linode instances on this account")
 	client := newLinodeClient()
 	ctx := context.Background()
-	linodes, err := client.ListInstances(ctx, nil)
-	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Fatal("Failed to list Linodes")
+
+	var linodes []linodego.Instance
+	var volumes []linodego.Volume
+	var nodebalancers []linodego.NodeBalancer
+	var domains []linodego.Domain
+	var lkeclusters []linodego.LKECluster
+
+	linodeObjects := []interface{}{
+		linodes,
+		volumes,
+		nodebalancers,
+		domains,
+		lkeclusters}
+
+	for _, linodeObjects := range linodeObjects {
+		var err error
+		switch linodeObjects.(type) {
+		case []linodego.Instance:
+			linodes, err = client.ListInstances(ctx, nil)
+		case []linodego.Volume:
+			volumes, err = client.ListVolumes(ctx, nil)
+		case []linodego.NodeBalancer:
+			nodebalancers, err = client.ListNodeBalancers(ctx, nil)
+		case []linodego.Domain:
+			domains, err = client.ListDomains(ctx, nil)
+		case []linodego.LKECluster:
+			lkeclusters, err = client.ListLKEClusters(ctx, nil)
+		}
+
+		if err != nil {
+			log.WithFields(log.Fields{"err": err}).Fatal("Failed to list Linode object")
+		}
 	}
 
+	linodeObjects = []interface{}{
+		linodes,
+		volumes,
+		nodebalancers,
+		domains,
+		lkeclusters}
+
+	linodeTagSlice := make(map[string][]TagRule)
+	linodeTagSlice["linodes"] = config.Instances
+	linodeTagSlice["volumes"] = config.Volumes
+	linodeTagSlice["nodebalancers"] = config.NodeBalancers
+	linodeTagSlice["domains"] = config.Domains
+	linodeTagSlice["lkeclusters"] = config.LKEClusters
+
 	log.Info("Checking linode instance tags against config file")
-	tagMap, err := checkLinodeTagsAgainstConfig(linodes, config.Instances)
+	tagMap, err := checkTagsAgainstConfig(
+		linodeObjects, linodeTagSlice)
+
 	if err != nil {
 		log.WithFields(log.Fields{
 			"err": err,
@@ -358,17 +661,17 @@ func main() {
 		if err := updateAllInstanceTags(ctx, client, tagMap); err != nil {
 			log.WithFields(log.Fields{
 				"err": err,
-			}).Error("Failed to apply new tag sets to instances")
+			}).Error("Failed to apply new tag sets to objects")
 		}
 	} else {
 		log.Info("Dry run enabled, not applying tags.")
 	}
 
 	// build report data for use with report/json if requested
-	report := buildReport(tagMap, linodes)
+	report := buildReport(tagMap, linodeObjects)
 
 	if viper.GetBool("report") {
-		log.Info("Generating summary report of changes.")
+		log.Info("Generating summary report of changes")
 		genReport(report)
 	}
 

--- a/tagger.go
+++ b/tagger.go
@@ -45,7 +45,7 @@ type TaggerConfig struct {
 	Volumes       []TagRule `yaml:"volumes"`
 	NodeBalancers []TagRule `yaml:"nodebalancers"`
 	Domains       []TagRule `yaml:"domains"`
-	LKEClusters   []TagRule `yaml:"lkeclusters"`
+	LKEClusters   []TagRule `yaml:"lke_clusters"`
 }
 
 func newLinodeClient() linodego.Client {

--- a/tagger.go
+++ b/tagger.go
@@ -616,32 +616,32 @@ func main() {
 		domains,
 		lkeclusters}
 
-	for _, linodeObjects := range linodeObjects {
+	counter := 0
+	for _, objects := range linodeObjects {
 		var err error
-		switch linodeObjects.(type) {
+		switch objects.(type) {
 		case []linodego.Instance:
 			linodes, err = client.ListInstances(ctx, nil)
+			linodeObjects[counter] = linodes
 		case []linodego.Volume:
 			volumes, err = client.ListVolumes(ctx, nil)
+			linodeObjects[counter] = volumes
 		case []linodego.NodeBalancer:
 			nodebalancers, err = client.ListNodeBalancers(ctx, nil)
+			linodeObjects[counter] = nodebalancers
 		case []linodego.Domain:
 			domains, err = client.ListDomains(ctx, nil)
+			linodeObjects[counter] = domains
 		case []linodego.LKECluster:
 			lkeclusters, err = client.ListLKEClusters(ctx, nil)
+			linodeObjects[counter] = lkeclusters
 		}
 
 		if err != nil {
 			log.WithFields(log.Fields{"err": err}).Fatal("Failed to list Linode object")
 		}
+		counter++
 	}
-
-	linodeObjects = []interface{}{
-		linodes,
-		volumes,
-		nodebalancers,
-		domains,
-		lkeclusters}
 
 	objectTags := make(map[string][]TagRule)
 	objectTags["linodes"] = config.Instances

--- a/tagger.go
+++ b/tagger.go
@@ -246,7 +246,8 @@ func updateObjectTags(ctx context.Context, client linodego.Client, id int, tags 
 			sort.Strings(updatedTags)
 
 			if !slices.Equal(updatedTags, *tags) {
-				return errors.New("call to update instance did not result in the expected tag set")
+				errString := "call to update instance failed: expected " + strings.Join(updatedTags, ", ") + ", got: " + strings.Join(*tags, ", ")
+				return errors.New(errString)
 			}
 		case "volumes":
 			updatedObject, err := client.UpdateVolume(ctx, id, linodego.VolumeUpdateOptions{Tags: tags})
@@ -258,7 +259,8 @@ func updateObjectTags(ctx context.Context, client linodego.Client, id int, tags 
 			sort.Strings(updatedTags)
 
 			if !slices.Equal(updatedTags, *tags) {
-				return errors.New("call to update volume did not result in the expected tag set")
+				errString := "call to update volume failed; expected " + strings.Join(updatedTags, ", ") + ", got: " + strings.Join(*tags, ", ")
+				return errors.New(errString)
 			}
 		case "nodebalancers":
 			updatedObject, err := client.UpdateNodeBalancer(ctx, id, linodego.NodeBalancerUpdateOptions{Tags: tags})
@@ -269,7 +271,8 @@ func updateObjectTags(ctx context.Context, client linodego.Client, id int, tags 
 			updatedTags := updatedObject.Tags
 			sort.Strings(updatedTags)
 			if !slices.Equal(updatedTags, *tags) {
-				return errors.New("call to update nodebalancer did not result in the expected tag set")
+				errString := "call to update nodebalancer failed; expected " + strings.Join(updatedTags, ", ") + ", got: " + strings.Join(*tags, ", ")
+				return errors.New(errString)
 			}
 		case "domains":
 			updatedObject, err := client.UpdateDomain(ctx, id, linodego.DomainUpdateOptions{Tags: *tags})
@@ -280,7 +283,8 @@ func updateObjectTags(ctx context.Context, client linodego.Client, id int, tags 
 			updatedTags := updatedObject.Tags
 			sort.Strings(updatedTags)
 			if !slices.Equal(updatedTags, *tags) {
-				return errors.New("call to update domain did not result in the expected tag set")
+				errString := "call to update domain failed; expected " + strings.Join(updatedTags, ", ") + ", got: " + strings.Join(*tags, ", ")
+				return errors.New(errString)
 			}
 		case "lkeclusters":
 			updatedObject, err := client.UpdateLKECluster(ctx, id, linodego.LKEClusterUpdateOptions{Tags: tags})
@@ -291,7 +295,8 @@ func updateObjectTags(ctx context.Context, client linodego.Client, id int, tags 
 			updatedTags := updatedObject.Tags
 			sort.Strings(updatedTags)
 			if !slices.Equal(updatedTags, *tags) {
-				return errors.New("call to update lkecluster did not result in the expected tag set")
+				errString := "call to update lke_cluster failed; expected " + strings.Join(updatedTags, ", ") + ", got: " + strings.Join(*tags, ", ")
+				return errors.New(errString)
 			}
 
 		}

--- a/tagger.go
+++ b/tagger.go
@@ -609,45 +609,28 @@ func main() {
 	client := newLinodeClient()
 	ctx := context.Background()
 
-	var linodes []linodego.Instance
-	var volumes []linodego.Volume
-	var nodebalancers []linodego.NodeBalancer
-	var domains []linodego.Domain
-	var lkeclusters []linodego.LKECluster
-
-	linodeObjects := []interface{}{
-		linodes,
-		volumes,
-		nodebalancers,
-		domains,
-		lkeclusters}
-
-	counter := 0
-	for _, objects := range linodeObjects {
-		var err error
-		switch objects.(type) {
-		case []linodego.Instance:
-			linodes, err = client.ListInstances(ctx, nil)
-			linodeObjects[counter] = linodes
-		case []linodego.Volume:
-			volumes, err = client.ListVolumes(ctx, nil)
-			linodeObjects[counter] = volumes
-		case []linodego.NodeBalancer:
-			nodebalancers, err = client.ListNodeBalancers(ctx, nil)
-			linodeObjects[counter] = nodebalancers
-		case []linodego.Domain:
-			domains, err = client.ListDomains(ctx, nil)
-			linodeObjects[counter] = domains
-		case []linodego.LKECluster:
-			lkeclusters, err = client.ListLKEClusters(ctx, nil)
-			linodeObjects[counter] = lkeclusters
-		}
-
-		if err != nil {
-			log.WithFields(log.Fields{"err": err}).Fatal("Failed to list object")
-		}
-		counter++
+	linodes, err := client.ListInstances(ctx, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Fatal("Failed to list linodes")
 	}
+	volumes, err := client.ListVolumes(ctx, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Fatal("Failed to list volumes")
+	}
+	nodebalancers, err := client.ListNodeBalancers(ctx, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Fatal("Failed to list nodebalancers")
+	}
+	domains, err := client.ListDomains(ctx, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Fatal("Failed to list domains")
+	}
+	lkeclusters, err := client.ListLKEClusters(ctx, nil)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Fatal("Failed to list lkeclusters")
+	}
+
+	linodeObjects := []interface{}{linodes, volumes, nodebalancers, domains, lkeclusters}
 
 	objectTags := make(map[string][]TagRule)
 	objectTags["linodes"] = config.Instances


### PR DESCRIPTION
This adds the ability to additionally tag volumes, nodebalanacers,
domains and lkeclusters. Report/JSON output has been updated to support
this new output too.

The readme changes highlight support for all the taggable Linode APIv4
objects, in conjunction with the new sample tagger config.

Now, the tagger config not only shows all the different resource types you
can tag but highlights some common use cases and syntax (multiple tags,
empty list).
