### PR TITLE
ref!: use discrete structs rather than raw interfaces/maps

### DIFF
--- a/tagger.go
+++ b/tagger.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/linode/linodego"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
@@ -825,48 +824,6 @@ func buildReport(desiredTagMap objectTagMap, linodeObjects []interface{}) Report
 	return report
 }
 
-func genReport(report ReportMap) {
-	// create a pretty table
-	t := table.NewWriter()
-	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(table.Row{"tag", "Objects Changed", "Objects", "Object Type", "Added/Removed"})
-	for objectType := range report {
-		for tag, data := range report[objectType] {
-
-			addObjectList := strings.Join(data.ObjectsAdded, ", ")
-			removeObjectList := strings.Join(data.ObjectsRemoved, ", ")
-
-			removeCount := len(data.ObjectsRemoved)
-			addCount := len(data.ObjectsAdded)
-			if removeCount >= 1 {
-				t.AppendRow(table.Row{
-					tag,
-					removeCount,
-					removeObjectList,
-					objectType,
-					"Removed",
-				})
-			}
-			if addCount >= 1 {
-				t.AppendRow(table.Row{
-					tag,
-					addCount,
-					addObjectList,
-					objectType,
-					"Added"})
-			}
-		}
-	}
-	t.SetAutoIndex(true)
-	t.SetColumnConfigs([]table.ColumnConfig{
-		{
-			WidthMax: 64,
-		},
-	})
-	t.SetStyle(table.StyleLight)
-	t.Render()
-}
-
 func genJSON(diff LinodeObjectCollectionDiff) error {
 	bytes, err := json.Marshal(diff)
 	if err != nil {
@@ -917,7 +874,6 @@ func main() {
 	flag.String("config", "", "Path to configuration file to use")
 	flag.String("logging.level", "", "Logging level may be one of: trace, debug, info, warning, error, fatal and panic")
 	flag.Bool("dry-run", false, "Don't apply the tag changes")
-	flag.Bool("report", false, "Report output to summarize tag changes")
 	flag.Bool("json", false, "Provide changes in JSON")
 	flag.BoolP("version", "v", false, "Print version information about this build of tagger")
 
@@ -1040,12 +996,6 @@ func tagger(config TaggerConfig) {
 
 	// build report data for use with report/json if requested
 	// report := buildReport(tagMap, linodeObjects)
-
-	if viper.GetBool("report") {
-		log.Info("Generating summary report of changes")
-		// TODO: fix report generation
-		// genReport(report)
-	}
 
 	if viper.GetBool("json") {
 		if err := genJSON(tagDiff); err != nil {

--- a/tagger.go
+++ b/tagger.go
@@ -65,6 +65,42 @@ type LinodeObjectCollection struct {
 	LKEClusters   []linodego.LKECluster
 }
 
+// LinodeObjectTags holds an object's ID, as well as the desired set of tags that it should have.
+type LinodeObjectDesiredTags struct {
+	ID  int
+	Old []string
+	New []string
+}
+
+type LinodeObjectDesiredTagsCollection struct {
+	Instances     []LinodeObjectDesiredTags
+	Domains       []LinodeObjectDesiredTags
+	NodeBalancers []LinodeObjectDesiredTags
+	LKEClusters   []LinodeObjectDesiredTags
+	Volumes       []LinodeObjectDesiredTags
+}
+
+// Diff contains a list of tags that have been added/removed from a given
+// object
+type Diff struct {
+	Added   []string `json:"added"`
+	Removed []string `json:"removed"`
+}
+
+type LinodeObjectDiff struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
+	Diff  `json:"diff"`
+}
+
+type LinodeObjectCollectionDiff struct {
+	Instances     []LinodeObjectDiff `json:"instances"`
+	Domains       []LinodeObjectDiff `json:"domains"`
+	NodeBalancers []LinodeObjectDiff `json:"nodebalancers"`
+	LKEClusters   []LinodeObjectDiff `json:"lkeclusters"`
+	Volumes       []LinodeObjectDiff `json:"volumes"`
+}
+
 func newLinodeClient() linodego.Client {
 	apiKey, ok := os.LookupEnv("LINODE_TOKEN")
 	if !ok {
@@ -169,6 +205,247 @@ func logTags(combinedNewTags []string, tags []string, objectID int, objectType s
 			}).Debug("Object tag set updated")
 		}
 	}
+}
+
+// getTagDiff accepts 2 string slices (the current set of tags, and the desired
+// set of tags). It outputs a Diff object containing the changes
+func getTagDiff(have, want []string) Diff {
+	var d Diff
+
+	sort.Strings(have)
+	sort.Strings(want)
+	if !slices.Equal(have, want) {
+		// order of have and object.have differs based on whether we're subtracting or contributing more have
+		d.Added = sliceDifference(want, have)
+		d.Removed = sliceDifference(have, want)
+	}
+
+	return d
+}
+
+func getLinodeObjectCollectionDiff(loc LinodeObjectCollection, desiredTags LinodeObjectDesiredTagsCollection) LinodeObjectCollectionDiff {
+	diff := LinodeObjectCollectionDiff{}
+
+	// instances
+	for _, old := range desiredTags.Instances {
+		for _, cur := range loc.Instances {
+			if old.ID != cur.ID {
+				continue
+			}
+
+			diff.Instances = append(diff.Instances, LinodeObjectDiff{
+				ID:    cur.ID,
+				Label: cur.Label,
+				Diff:  getTagDiff(old.Old, cur.Tags),
+			})
+		}
+	}
+
+	// domains
+	for _, old := range desiredTags.Domains {
+		for _, cur := range loc.Domains {
+			if old.ID != cur.ID {
+				continue
+			}
+
+			diff.Domains = append(diff.Domains, LinodeObjectDiff{
+				ID:    cur.ID,
+				Label: cur.Domain,
+				Diff:  getTagDiff(old.Old, cur.Tags),
+			})
+		}
+	}
+
+	// lke clusters
+	for _, old := range desiredTags.LKEClusters {
+		for _, cur := range loc.LKEClusters {
+			if old.ID != cur.ID {
+				continue
+			}
+
+			diff.LKEClusters = append(diff.LKEClusters, LinodeObjectDiff{
+				ID:    cur.ID,
+				Label: cur.Label,
+				Diff:  getTagDiff(old.Old, cur.Tags),
+			})
+		}
+	}
+
+	// volumes
+	for _, old := range desiredTags.Volumes {
+		for _, cur := range loc.Volumes {
+			if old.ID != cur.ID {
+				continue
+			}
+
+			diff.Volumes = append(diff.Volumes, LinodeObjectDiff{
+				ID:    cur.ID,
+				Label: cur.Label,
+				Diff:  getTagDiff(old.Old, cur.Tags),
+			})
+		}
+	}
+	// nodebalancers
+	for _, old := range desiredTags.NodeBalancers {
+		for _, cur := range loc.NodeBalancers {
+			if old.ID != cur.ID {
+				continue
+			}
+
+			diff.NodeBalancers = append(diff.NodeBalancers, LinodeObjectDiff{
+				ID:    cur.ID,
+				Label: *cur.Label,
+				Diff:  getTagDiff(old.Old, cur.Tags),
+			})
+		}
+	}
+
+	return diff
+}
+
+// getNewTags accepts an object's string label, an object's existing set of
+// tags, and a slice of TagRules to apply to the given object type. The regex
+// in the TagRule is matched against the provided label. This function returns
+// a string slice, which is the desired set of tags that the given object
+// should have according to the config.
+func getNewTags(objectLabel string, tags []string, rules []TagRule) []string {
+	if len(rules) > 0 {
+		sort.Strings(tags)
+		var combinedNewTags []string
+
+		// iterate through tag rules for instances and compare
+		for _, rule := range rules {
+			validRegex := regexp.MustCompile(rule.Regex)
+
+			if validRegex.MatchString(objectLabel) {
+				var newTags []string
+
+				// check `absent` tags to remove unwanted tags
+				for _, tag := range tags {
+					if !slices.Contains(rule.Tags.Absent, tag) {
+						// if this tag is not on the `absent` list,
+						// we can persist it through to the new tag set
+						newTags = append(newTags, tag)
+					}
+				}
+
+				// check `present` tags to ensure specific tags exist
+				for _, tag := range rule.Tags.Present {
+					// compare filter against `newTags`, as
+					// newTags == (the linode's tags - absent tags)
+					if !slices.Contains(newTags, tag) {
+						// if the specified tag does not exist,
+						// add it into the new tag set
+						newTags = append(newTags, tag)
+					}
+				}
+
+				// add newTags to combined list of new tags for this instance,
+				// excluding duplicates
+				for _, tag := range newTags {
+					if !slices.Contains(combinedNewTags, tag) {
+						combinedNewTags = append(combinedNewTags, tag)
+					}
+				}
+			}
+		}
+
+		return combinedNewTags
+	}
+
+	return tags
+}
+
+func compareAllObjectTagsAgainstConfig(loc LinodeObjectCollection, config TaggerConfig) (LinodeObjectDesiredTagsCollection, LinodeObjectCollectionDiff) {
+	desiredNewTags := LinodeObjectDesiredTagsCollection{}
+	diff := LinodeObjectCollectionDiff{}
+
+	// instances
+	for _, instance := range loc.Instances {
+		newTags := getNewTags(instance.Label, instance.Tags, config.Instances)
+
+		desiredNewTags.Instances = append(desiredNewTags.Instances, LinodeObjectDesiredTags{
+			ID:  instance.ID,
+			Old: instance.Tags,
+			New: newTags,
+		})
+
+		diff.Instances = append(diff.Instances, LinodeObjectDiff{
+			ID:    instance.ID,
+			Label: instance.Label,
+			Diff:  getTagDiff(instance.Tags, newTags),
+		})
+	}
+
+	// domains
+	for _, domain := range loc.Domains {
+		newTags := getNewTags(domain.Domain, domain.Tags, config.Domains)
+
+		desiredNewTags.Domains = append(desiredNewTags.Domains, LinodeObjectDesiredTags{
+			ID:  domain.ID,
+			Old: domain.Tags,
+			New: newTags,
+		})
+
+		diff.Domains = append(diff.Domains, LinodeObjectDiff{
+			ID:    domain.ID,
+			Label: domain.Domain,
+			Diff:  getTagDiff(domain.Tags, newTags),
+		})
+	}
+
+	// LKE clusters
+	for _, lke := range loc.LKEClusters {
+		newTags := getNewTags(lke.Label, lke.Tags, config.LKEClusters)
+
+		desiredNewTags.LKEClusters = append(desiredNewTags.LKEClusters, LinodeObjectDesiredTags{
+			ID:  lke.ID,
+			Old: lke.Tags,
+			New: newTags,
+		})
+
+		diff.LKEClusters = append(diff.LKEClusters, LinodeObjectDiff{
+			ID:    lke.ID,
+			Label: lke.Label,
+			Diff:  getTagDiff(lke.Tags, newTags),
+		})
+	}
+
+	// volumes
+	for _, volume := range loc.Volumes {
+		newTags := getNewTags(volume.Label, volume.Tags, config.Volumes)
+
+		desiredNewTags.Volumes = append(desiredNewTags.Volumes, LinodeObjectDesiredTags{
+			ID:  volume.ID,
+			Old: volume.Tags,
+			New: newTags,
+		})
+
+		diff.Volumes = append(diff.Volumes, LinodeObjectDiff{
+			ID:    volume.ID,
+			Label: volume.Label,
+			Diff:  getTagDiff(volume.Tags, newTags),
+		})
+	}
+
+	// nodebalancers
+	for _, nb := range loc.NodeBalancers {
+		newTags := getNewTags(*nb.Label, nb.Tags, config.NodeBalancers)
+
+		desiredNewTags.NodeBalancers = append(desiredNewTags.NodeBalancers, LinodeObjectDesiredTags{
+			ID:  nb.ID,
+			Old: nb.Tags,
+			New: newTags,
+		})
+
+		diff.NodeBalancers = append(diff.NodeBalancers, LinodeObjectDiff{
+			ID:    nb.ID,
+			Label: *nb.Label,
+			Diff:  getTagDiff(nb.Tags, newTags),
+		})
+	}
+
+	return desiredNewTags, diff
 }
 
 func checkTagsAgainstConfig(
@@ -323,17 +600,80 @@ func updateObjectTags(ctx context.Context, client linodego.Client, id int, tags 
 	return nil
 }
 
-func updateAllObjectTags(ctx context.Context, client linodego.Client, tagMap objectTagMap) error {
-	for data := range tagMap {
+func updateAllObjectTags(ctx context.Context, client linodego.Client, desiredTags LinodeObjectDesiredTagsCollection) (LinodeObjectCollection, error) {
+	var loc LinodeObjectCollection
 
-		for id, tags := range tagMap[data] {
-			if err := updateObjectTags(ctx, client, id, &tags, data); err != nil {
-				return err
-			}
+	// update instance tags
+	for _, i := range desiredTags.Instances {
+		updatedInstance, err := client.UpdateInstance(ctx, i.ID, linodego.InstanceUpdateOptions{Tags: &i.New})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"id":    i.ID,
+				"error": err,
+			}).Error("Failed to update instance tags")
+			return loc, err
 		}
+
+		loc.Instances = append(loc.Instances, *updatedInstance)
 	}
 
-	return nil
+	// update domain tags
+	for _, d := range desiredTags.Domains {
+		updatedDomain, err := client.UpdateDomain(ctx, d.ID, linodego.DomainUpdateOptions{Tags: d.New})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"id":    d.ID,
+				"error": err,
+			}).Error("Failed to update domain tags")
+			return loc, err
+		}
+
+		loc.Domains = append(loc.Domains, *updatedDomain)
+	}
+
+	// update nodebalancer tags
+	for _, nb := range desiredTags.NodeBalancers {
+		updatedNodeBalancer, err := client.UpdateNodeBalancer(ctx, nb.ID, linodego.NodeBalancerUpdateOptions{Tags: &nb.New})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"id":    nb.ID,
+				"error": err,
+			}).Error("Failed to update nodebalancer tags")
+			return loc, err
+		}
+
+		loc.NodeBalancers = append(loc.NodeBalancers, *updatedNodeBalancer)
+	}
+
+	// update lkecluster tags
+	for _, lke := range desiredTags.LKEClusters {
+		updatedLKECluster, err := client.UpdateLKECluster(ctx, lke.ID, linodego.LKEClusterUpdateOptions{Tags: &lke.New})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"id":    lke.ID,
+				"error": err,
+			}).Error("Failed to update LKE Cluster tags")
+			return loc, err
+		}
+
+		loc.LKEClusters = append(loc.LKEClusters, *updatedLKECluster)
+	}
+
+	// update volume tags
+	for _, v := range desiredTags.Volumes {
+		updatedVolume, err := client.UpdateVolume(ctx, v.ID, linodego.VolumeUpdateOptions{Tags: &v.New})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"id":    v.ID,
+				"error": err,
+			}).Error("Failed to update v Cluster tags")
+			return loc, err
+		}
+
+		loc.Volumes = append(loc.Volumes, *updatedVolume)
+	}
+
+	return loc, nil
 }
 
 // sliceDifference returns the elements in `a` that aren't in `b`.
@@ -527,19 +867,13 @@ func genReport(report ReportMap) {
 	t.Render()
 }
 
-func genJSON(report ReportMap) error {
-	// convert ReportMap to JSON and send to stdout
-	for objectType := range report {
-		for tag, data := range report[objectType] {
-			report[objectType][tag] = data
-		}
-	}
-	stdout, err := json.Marshal(report)
-	fmt.Println(string(stdout))
-
+func genJSON(diff LinodeObjectCollectionDiff) error {
+	bytes, err := json.Marshal(diff)
 	if err != nil {
 		return err
 	}
+
+	fmt.Println(string(bytes))
 	return nil
 }
 
@@ -686,48 +1020,35 @@ func tagger(config TaggerConfig) {
 		loc.LKEClusters = lkeclusters
 	}
 
-	// TODO: convert other uses of these []interface configs -> LinodeObjectCollection struct usage? 
-	// should be able to reduce a lot of the type assertions used elsewhere if we just use the explicit types
-	linodeObjects := []interface{}{loc.Instances, loc.Volumes, loc.NodeBalancers, loc.Domains, loc.LKEClusters}
-
-	objectTags := make(map[string][]TagRule)
-	objectTags["linodes"] = config.Instances
-	objectTags["volumes"] = config.Volumes
-	objectTags["nodebalancers"] = config.NodeBalancers
-	objectTags["domains"] = config.Domains
-	objectTags["lkeclusters"] = config.LKEClusters
-
 	log.Info("Checking linode object tags against config file")
-	tagMap, err := checkTagsAgainstConfig(
-		linodeObjects, objectTags)
-
-	if err != nil {
-		log.WithFields(log.Fields{
-			"err": err,
-		}).Error("Failed to retrieve tag map of objects that need to be updated")
-	}
+	// TODO: fix actually use tag diff in dry run
+	desiredTags, tagDiff := compareAllObjectTagsAgainstConfig(loc, config)
 
 	if !viper.GetBool("dry-run") {
 		log.Info("Applying new tags to objects that need updating")
-		if err := updateAllObjectTags(ctx, client, tagMap); err != nil {
+		newLoc, err := updateAllObjectTags(ctx, client, desiredTags)
+		if err != nil {
 			log.WithFields(log.Fields{
 				"err": err,
 			}).Error("Failed to apply new tag sets to objects")
 		}
+		tagDiff = getLinodeObjectCollectionDiff(newLoc, desiredTags)
 	} else {
 		log.Info("Dry run enabled, not applying tags.")
 	}
 
+
 	// build report data for use with report/json if requested
-	report := buildReport(tagMap, linodeObjects)
+	// report := buildReport(tagMap, linodeObjects)
 
 	if viper.GetBool("report") {
 		log.Info("Generating summary report of changes")
-		genReport(report)
+		// TODO: fix report generation
+		// genReport(report)
 	}
 
 	if viper.GetBool("json") {
-		if err := genJSON(report); err != nil {
+		if err := genJSON(tagDiff); err != nil {
 			log.WithFields(log.Fields{
 				"err": err,
 			}).Error("Failed to generate JSON report output")

--- a/tagger.go
+++ b/tagger.go
@@ -114,17 +114,17 @@ func newLinodeClient() linodego.Client {
 // getTagDiff accepts 2 string slices (the current set of tags, and the desired
 // set of tags). It outputs a Diff object containing the changes
 func getTagDiff(have, want []string) Diff {
-	var d Diff
+	var diff Diff
 
 	sort.Strings(have)
 	sort.Strings(want)
 	if !slices.Equal(have, want) {
 		// order of have and object.have differs based on whether we're subtracting or contributing more have
-		d.Added = sliceDifference(want, have)
-		d.Removed = sliceDifference(have, want)
+		diff.Added = sliceDifference(want, have)
+		diff.Removed = sliceDifference(have, want)
 	}
 
-	return d
+	return diff
 }
 
 // getLinodeObjectCollectionDiff accepts a LinodeObjectCollection and


### PR DESCRIPTION
This commit is intended to make the code both easier to read/follow, as well as prevent accidental logic errors that might come about from using raw interfaces and composite maps.

This commit is a fairly large refactor, as it seemed it would be even more complicated to try and get functional code in partial commits to try and make the changeset easier to follow. To that end, this commit is add-only; it does not remove any old code, it simply adds new functions and updates the call chain in main.

Changes included:
- new structs to hold organized data for diffs and "desired" tag data (ie, data that will be used to update objects on the account)
- new composite structs (collections) that hold diffs/desired tag data sets for each object type (instances, volumes, domains, nodebalancers, lke clusters)
- new diff/comparison functions that work with the new structs
- fixed/improved diff checking when updating tags (ie, not using `dry-run`)

Still to be done:
- `genReport()` func needs to be updated to use new structs
- clean/remove old code