### PR TITLE
fix: only enable file/func log prettifiers at debug level or higher

### DIFF
--- a/tagger.go
+++ b/tagger.go
@@ -508,16 +508,6 @@ func init() {
 			log.DebugLevel,
 		},
 	})
-
-	// enable func/file logging
-	log.SetReportCaller(true)
-	log.SetFormatter(&log.TextFormatter{
-		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-			fileName := filepath.Base(f.File)
-			funcName := filepath.Base(f.Function)
-			return fmt.Sprintf("%s()", funcName), fmt.Sprintf("%s:%d", fileName, f.Line)
-		},
-	})
 }
 
 func version() {
@@ -584,6 +574,18 @@ func main() {
 		log.SetLevel(log.InfoLevel)
 	} else {
 		log.SetLevel(level)
+		if level >= log.DebugLevel {
+			// enable func/file logging
+			log.SetReportCaller(true)
+			log.SetFormatter(&log.TextFormatter{
+				CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+					fileName := filepath.Base(f.File)
+					funcName := filepath.Base(f.Function)
+					return fmt.Sprintf("%s()", funcName), fmt.Sprintf("%s:%d", fileName, f.Line)
+				},
+			})
+		}
+
 		log.Infof("Log level set to: %s", level)
 	}
 


### PR DESCRIPTION
This helps keep normal `info` level log output a little more manageable, while still setting the relevant log keys at the appropriate levels.

Example:
```
~/go/src/github.com/tjhop/linode-tagger (fix-log-prettifiers [ U ]) -> ./dist/linode-tagger_linux_amd64_v1/tagger --config packaging/etc/tagger.yml --dry-run >/dev/null
time="2022-12-23T00:42:05-05:00" level=info msg="Gathering objects on this account"
time="2022-12-23T00:42:05-05:00" level=info msg="Checking linode object tags against config file"
time="2022-12-23T00:42:05-05:00" level=info msg="Dry run enabled, not applying tags."
~/go/src/github.com/tjhop/linode-tagger (fix-log-prettifiers [ U ]) -> ./dist/linode-tagger_linux_amd64_v1/tagger --config packaging/etc/tagger.yml --dry-run --logging.level debug >/dev/null
time="2022-12-23T00:42:46-05:00" level=info msg="Log level set to: debug" func="main.main()" file="tagger.go:589"
time="2022-12-23T00:42:46-05:00" level=info msg="Gathering objects on this account" func="main.tagger()" file="tagger.go:596"
time="2022-12-23T00:42:47-05:00" level=info msg="Checking linode object tags against config file" func="main.tagger()" file="tagger.go:641"
time="2022-12-23T00:42:47-05:00" level=info msg="Dry run enabled, not applying tags." func="main.tagger()" file="tagger.go:654"
```